### PR TITLE
Minor changes to description of restart steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,58 +3,58 @@ change update_rho -> thetao_new => Restart["tn"]
 # EMULATOR FRO NEMO MODEL
 
 ![img1](img/emulator.png)
-Add retstart and prepare 
+Add retstart and prepare
 
 
 # Jumper.ipynb
 
-### *Prepare and forecast simulations* 
+### *Prepare and forecast simulations*
 
-The objective is to implement a Gaussian process forecast to forecast yearly simulations of NEMO coupled climate model. For this we need simulations files of the sea surface height (zos or ssh), the salinity (so) and temperature (thetao). 
+The objective is to implement a Gaussian process forecast to forecast yearly simulations of NEMO coupled climate model. For this we need simulations files of the sea surface height (zos or ssh), the salinity (so) and temperature (thetao).
 
 We apply PCA on each simulation to transform those features to time series. And we observe the trend in the first component.
 
 ![img1](img/jumper1.png)
 
 We forecast each component with a Gaussian process with the following kernel.
-- Long term trend   :  0.1*DotProduct(sigma_0=0.0) 
+- Long term trend   :  0.1*DotProduct(sigma_0=0.0)
 - Periodic patterns : 10 * ExpSineSquared(length_scale=5/45, periodicity=5/45)#0.5**2*RationalQuadratic(length_scale=5.0, alpha=1.0) + 10 * ExpSineSquared(length_scale=5.0)
 - White noise       : 2*WhiteKernel(noise_level=1)
 
-     
+
 
 ![img2](img/jumper3.png)
 
-And we evaluate the RMSE 
+And we evaluate the RMSE
 
 ![img2](img/jumper2.png)
 
 # Restart.ipynb
 
-### *Update of restart files for NEMO* 
+### *Update of restart files for NEMO*
 
 The objective is to update the last restart file to initialize the jump. For this we need the 340 restarts files of the last simulated year. We also need the predictions of the sea surface height (zos or ssh), the salinity (so) and temperature (thetao). We also need the Mask dataset of the corresponding simulation where several informations are needed.
 
 ![img5](img/img3.png)
 
-### 1 - Predicted features  
-- zos        : Predicted sea surface height (ssh) - grid T - t,y,x  
-- so         : Predicted salinity - grid T - t,z,y,x  
+### 1 - Predicted features
+- zos        : Predicted sea surface height (ssh) - grid T - t,y,x
+- so         : Predicted salinity - grid T - t,z,y,x
 - thetao     : Predicted temperature - grid T - t,z,y,x
 
-### 2 - Maskdataset  
+### 2 - Maskdataset
 **The Maskdataset contains mask on all grids, vectors and constants**
-  
-- dimensions t:1 y:331 x:360 z:75  
-- umask : continent mask for u grid (continent : 0, sea : 1)  
+
+- dimensions t:1 y:331 x:360 z:75
+- umask : continent mask for u grid (continent : 0, sea : 1)
 - vmask : continent mask for v grid (continent : 0, sea : 1)
 - e3t_0 : initial thickness of cell on z axis on grid T  (e:thickness, i:direction, t:grid, 0:initial state / ref) = e3t_ini restart
-- e2t   : thickness of cell on y axis on grid T  
+- e2t   : thickness of cell on y axis on grid T
 - e1t   : thickness of cell on y axis on grid T
-- ff_f  : corriolis force 
+- ff_f  : corriolis force
 
 ### 3 - Necessary features to update restart
-This is the list of features from the source restart file we need to exploit to update restart. 
+This is the list of features from the source restart file we need to exploit to update restart.
 
 - e3t : e3t_ini*(1+tmask4D*np.expand_dims(np.tile(ssh*ssmask/(bathy+(1-ssmask)),(75,1,1)),axis=0))
 - deptht : depth of the z axis - grid T
@@ -62,11 +62,11 @@ This is the list of features from the source restart file we need to exploit to 
 
 ### 4 - Restart file update
 **The restart files contains all physical and dynamical features of the simulation**
-  
-There is a total of 340 restart file per year. Each file contains a slice of x and y dimensions. Each files contains 58 data variables which 15 are updates using the predictions  
-  
 
-**NB** : difference between now (n) and before (b) arrays : they represent the same states, in practice the restart file save two successive states. In our code we set the two to the same state to use euler forward for the restart. 
+There is a total of 340 restart file per year. Each file contains a slice of x and y dimensions. Each files contains 58 data variables which 15 are updates using the predictions
+
+
+**NB** : difference between now (n) and before (b) arrays : they represent the same states, in practice the restart file save two successive states. In our code we set the two to the same state to use euler forward for the restart.
 
 - ssh(n/b) :  sea surface height       => last prediction of zos
 - s(n/b)   :  sea salinity             => last prediction of so
@@ -95,9 +95,9 @@ F
 
 # main
 
-### *Prepare and forecast simulations and initialize restarts files with one command line* 
+### *Prepare and forecast simulations and initialize restarts files with one command line*
 Prepare, forecats and predict
-NB : En amont code de Guillaume pour obtenir des moyennes annuelles 
+NB : En amont code de Guillaume pour obtenir des moyennes annuelles
 
 #python main.py --ye True --start 25 --end 65 --comp 0.9 --steps 30 --path /scratchu/mtissot/SIMUp6Y
 
@@ -114,37 +114,54 @@ NB : En amont code de Guillaume pour obtenir des moyennes annuelles
 
 ## Steps for running Spin-Up NEMO
 
-1. Run DINO for 50-100 years. Slurm script has been provided in NEMO [notes](https://github.com/m2lines/Spinup-NEMO-notes/blob/main/nemo/buildandrun_NEMODINO.md). If we need to train on more data we then need to concatentate simulation outputs `*grid_T.nc` using `ncrcat`. 
+1. Run DINO for 50-100 years. Slurm script has been provided in NEMO [notes](https://github.com/m2lines/Spinup-NEMO-notes/blob/main/nemo/buildandrun_NEMODINO.md). If we need to train on more data we then need to concatentate simulation outputs `*grid_T.nc` using `ncrcat`.
 
 2. Create a virtual environment, for example, with conda. Then install the requirements within it using `pip install -r requirements.txt`
 
-3. Run the resampling **notebook** on `DINO_1m_grid_T.nc` (See [run_with_DINO_data](https://github.com/m2lines/Spinup-NEMO/tree/run_with_DINO_data) branch). This is the [Notebook](https://github.com/m2lines/Spinup-NEMO/blob/resample_dino_data/Notebooks/Resample_ssh.ipynb)   
-  This notebook converts DINO 2d monthly SSH output `DINO_1m_grid_T.nc` to annual `DINO_1m_To_1y_grid_T.nc`. Temperature and salinity (3D) are sampled annually already and are in `DINO_1y_grid_T.nc`. We can then read these files in the updated notebook for DINO. 
-4. Run the updated `Jumper.ipynb` **notebook** and to create the projected state. 
-    1. In the Jumper Notebook set the `path` to the directory of the NEMO/DINO (Grid) data: 
+3. Run the resampling **notebook** on `DINO_1m_grid_T.nc` (See [run_with_DINO_data](https://github.com/m2lines/Spinup-NEMO/tree/run_with_DINO_data) branch). This is the [Notebook](https://github.com/m2lines/Spinup-NEMO/blob/resample_dino_data/Notebooks/Resample_ssh.ipynb)
+  This notebook converts DINO 2d monthly SSH output `DINO_1m_grid_T.nc` to annual `DINO_1m_To_1y_grid_T.nc`. Temperature and salinity (3D) are sampled annually already and are in `DINO_1y_grid_T.nc`. We can then read these files in the updated notebook for DINO.
+4. Run the updated `Jumper.ipynb` **notebook** and to create the projected state.
+    1. In the Jumper Notebook set the `path` to the directory of the NEMO/DINO (Grid) data:
     ![image](https://hackmd.io/_uploads/HkODLLHPyl.png)
 
 
-
 5. Prepare restart file:
-   Combine `mesh_mask_[0000].nc` files and `DINO_[<time>]_restart_[<process>].nc` (last files) using **[REBUILD_NEMO](https://forge.nemo-ocean.eu/nemo/nemo/-/tree/4.2.0/tools/REBUILD_NEMO)** tools
-6.
-   In the directory which holds your nemo data
-   Create a new restart file by running `main_restart.py`.
-  `python main_restart.py --restart_path "path/to/restart/file/directory" --radical DINO_[<time>]_restart --mask_file /path/to/mesh_mask.nc --prediction_path /path/to/simus_predicted`
-    `main_restart.py` 
-    This script has been modified to work on DINO data. This is in the [run_with_DINO_data](https://github.com/m2lines/Spinup-NEMO/tree/run_with_DINO_data) branch.
-    This creates an updated Restart file with the same names as the original but with 'NEW' prepended at the front.
-    
-7. Within the NEMO repository make a copy of DINO experiment directory. Delete old NEMO output files from the original experiment directory (mesh mask, restart files, grid files etc). The copy serves as a backup as data is overwritten on each run.
-8. Copy mesh mask and restart file to the original experiment directory
-9. Namelist config need to be updated:
-Open namelist_cfg and amend the following under namrun:
 
--    nn_it000 (the first timestep) (The last timestep +1)
--    nn_itend (the final timestep)
-- cn_ocerst_in (the restart name syntax - to coincide with the latest restart file)
-- ln_rstart (start from rest(F) or from a restart file (T).
- ![image](https://hackmd.io/_uploads/HJtsvsCPJe.png)
- 
+   Combine `mesh_mask_[0000].nc` files and `DINO_[<time>]_restart_[<process>].nc` (last files) using **[REBUILD_NEMO](https://forge.nemo-ocean.eu/nemo/nemo/-/tree/4.2.0/tools/REBUILD_NEMO)** tools.
+    The command looks something like:
+    ```
+    ./rebuild_nemo -n ./nam_rebuild /path/to/DINO/restart/file/DINO_00576000_restart 36
+    ./rebuild_nemo -n ./nam_rebuild /path/to/DINO/mesh_mask 36
+    ```
+    Where 36 in the above corresponds to the number of MPI processes.
+
+6.  In the directory which holds your NEMO data, create a new restart file by running `main_restart.py`:
+       ```bash
+        python main_restart.py
+        --restart_path "/path/to/restart/file/directory"
+        --radical DINO_[<time>]_restart
+        --mask_file /full/path/to/mesh_mask.nc
+        --prediction_path /full/path/to/directory/simus_predicted/
+      ```
+      where:
+      ```
+      --radical : refers to the prefix of the restart file.
+      <time> : corresponds to the most recent restart file time.
+      ```
+
+
+    The `main_restart.py` script has been modified to work on DINO data. This is in the [run_with_DINO_data](https://github.com/m2lines/Spinup-NEMO/tree/run_with_DINO_data) branch. It creates an updated restart file with the same names as the original but with 'NEW' prepended to the front.
+
+
+7. Within the NEMO repository make a copy of DINO experiment directory. Delete old NEMO output files from the original experiment directory (mesh mask, restart files, grid files etc). The copy serves as a backup as data is overwritten on each run.
+8. Copy `mesh_mask_<proc_id>.nc` and `DINO_[<time>]_restart_<proc_id>.nc` to the original experiment directory.
+9. Then modify the namelist_cfg file. Open namelist_cfg and amend the following under namrun:
+
+    - `nn_it000` (the first timestep) (The last timestep +1)
+    - `nn_itend` (the final timestep)
+    - `cn_ocerst_in` (the restart name syntax - to coincide with the latest restart file)
+    - `ln_rstart` (start from rest(F) or from a restart file (T) - therefore `.true.`
+
+  ![image](https://hackmd.io/_uploads/HJtsvsCPJe.png)
+
 10. Restart DINO with updated restart file.

--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ NB : En amont code de Guillaume pour obtenir des moyennes annuelles
     Where 36 in the above corresponds to the number of MPI processes.
 
 6.  In the directory which holds your NEMO data, create a new restart file by running `main_restart.py`:
-       ```bash
+      ```bash
         python main_restart.py
-        --restart_path "/path/to/restart/file/directory"
+        --restart_path /path/to/EXP00/
         --radical DINO_[<time>]_restart
-        --mask_file /full/path/to/mesh_mask.nc
+        --mask_file /full/path/to/EXP00/mesh_mask.nc
         --prediction_path /full/path/to/directory/simus_predicted/
       ```
       where:

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ NB : En amont code de Guillaume pour obtenir des moyennes annuelles
     The `main_restart.py` script has been modified to work on DINO data. This is in the [run_with_DINO_data](https://github.com/m2lines/Spinup-NEMO/tree/run_with_DINO_data) branch. It creates an updated restart file with the same names as the original but with 'NEW' prepended to the front.
 
 
-7. Within the NEMO repository make a copy of DINO experiment directory. Delete old NEMO output files from the original experiment directory (mesh mask, restart files, grid files etc). The copy serves as a backup as data is overwritten on each run.
-8. Copy `mesh_mask_<proc_id>.nc` and `DINO_[<time>]_restart_<proc_id>.nc` to the original experiment directory.
-9. Then modify the namelist_cfg file. Open namelist_cfg and amend the following under namrun:
+7.  Within the NEMO repository make a copy of DINO experiment directory. Delete old NEMO output files from the original experiment directory (mesh mask, restart files, grid files etc). The copy serves as a backup as data is overwritten on each run.
+8.  Copy `mesh_mask_<proc_id>.nc` and `DINO_[<time>]_restart_<proc_id>.nc` to the original experiment directory.
+9.  Then modify the namelist_cfg file. Open namelist_cfg and amend the following under namrun:
 
     - `nn_it000` (the first timestep) (The last timestep +1)
     - `nn_itend` (the final timestep)

--- a/main_forecast.py
+++ b/main_forecast.py
@@ -2,64 +2,134 @@ import numpy as np
 import pandas as pd
 import os
 import pickle
-import sys 
-import random 
+import sys
+import random
 import argparse
-sys.path.insert(0,"../lib/")
+
+sys.path.insert(0, "./lib/")
 from forecast import Predictions, Simulation, load_ts
 
 
-file_simu_prepared  = "/data/mtissot/spinup_data/simus_prepared"
-file_simu_predicted = "/data/mtissot/spinup_data/simus_predicted"
+file_simu_prepared = "/rds/project/rds-5mCMIDBOkPU/ma595/nemo/NEMO/nemo_4.2.1/tests/DINO/concatenate_grid_150/simus_prepared_2"
+file_simu_predicted = "/rds/project/rds-5mCMIDBOkPU/ma595/nemo/NEMO/nemo_4.2.1/tests/DINO/concatenate_grid_150/simus_predicted_2"
 
 
-def prepare(term,simu_path, start, end, ye, comp):
-    simu = Simulation(path=simu_path,start=start,end=end,ye=ye,comp=comp,term=term)  #Load yearly or monthly simulations                    
-    print(f"{term} loaded")                                                                   
-    simu.prepare()                      #Prepare simulations : start to end - removeClosedSeas - (removeSSCA) - standardize - to numpy
-    print(f"{term} prepared")  
-    simu.applyPCA()                     #Exctract time series through PCA 
-    print(f"PCA applied on {term}")
-    simu.save(file_simu_prepared,term)  #Create dico and save: time series - mask - desc -(ssca) - cut(=start) - x_size - y_size - (z_size) - shape
-    print(f"{term} saved at {file_simu_prepared}/{term}")
-    del simu                            #Clean RAM
+def prepare(term, simu_path, start, end, ye, comp):
+    """
+    Prepare the simulation for the forecast
 
-def jump(term,steps):
-    df,infos = load_ts(f"{file_simu_prepared}/{term}",term)              #load dataframe and infos
-    simu_ts  = Predictions(term,df,infos)                                #create the class to predict
-    print(f"{term} time series loaded") 
-    y_hat, y_hat_std, metrics = simu_ts.Forecast(len(simu_ts),steps)     #Forecast
-    print(f"{term} time series forcasted") 
-    n = len(simu_ts.info["pca"].components_)                             #Reconstruct n predicted components
-    predictions_zos = simu_ts.reconstruct(y_hat,n,begin=len(simu_ts))
-    print(f"{term} predictions reconstructed") 
-    np.save(f"{file_simu_predicted}/{term}.npy", predictions_zos)        #Save
-    print(f"{term} predictions saved at {file_simu_predicted}") 
+    Args:
+    term (str): term to forecast
+    simu_path (str): path to the simulation
+    start (int): start of the simulation
+    end (int): end of the simulation
+    ye (bool): transform monthly simulation to yearly simulation
+    comp (int or float): explained variance ratio for the pcaA
+
+    Returns:
+    None
+
+    """
+    simu = Simulation(
+        path=simu_path, start=start, end=end, ye=ye, comp=comp, term=term
+    )  # Load yearly or monthly simulations
+    print(f"{term[0]} loaded")
+    simu.prepare()  # Prepare simulations : start to end - removeClosedSeas - (removeSSCA) - standardize - to numpy
+    print(f"{term[0]} prepared")
+    simu.applyPCA()  # Exctract time series through PCA
+    print(f"PCA applied on {term[0]}")
+
+    os.makedirs(f'{file_simu_prepared}/{term[0]}', exist_ok=True)
+
+    print(f'{file_simu_prepared}/{term[0]}')
+
+    simu.save(
+        file_simu_prepared, term[0]
+    )  # Create dico and save: time series - mask - desc -(ssca) - cut(=start) - x_size - y_size - (z_size) - shape
+    print(f"{term[0]} saved at {file_simu_prepared}/{term[0]}")
+    del simu  # Clean RAM
+
+
+def jump(term, steps):
+    df, infos = load_ts(
+        f"{file_simu_prepared}/{term}", term
+    )  # load dataframe and infos
+    simu_ts = Predictions(term, df, infos)  # create the class to predict
+    print(f"{term} time series loaded")
+    y_hat, y_hat_std, metrics = simu_ts.Forecast(len(simu_ts), steps)  # Forecast
+    print(f"{term} time series forcasted")
+    n = len(simu_ts.info["pca"].components_)  # Reconstruct n predicted components
+    predictions_zos = simu_ts.reconstruct(y_hat, n, begin=len(simu_ts))
+    print(f"{term} predictions reconstructed")
+
+    os.makedirs(f'{file_simu_predicted}/{term[0]}', exist_ok=True)
+    np.save(f"{file_simu_predicted}/{term}.npy", predictions_zos)  # Save
+    print(f"{term} predictions saved at {file_simu_predicted}")
     del simu_ts
 
-def emulate(simu_path,steps,ye,start,end,comp):
-    for term in ["zos","so","thetao"]:
-        print(f"Preparing {term}...")
-        prepare(term,simu_path, ye, start, end, comp)
+
+def emulate(simu_path, steps, ye, start, end, comp):
+    # for term in ["zos","so","thetao"]:
+    #     print(f"Preparing {term}...")
+    #     prepare(term,simu_path, ye, start, end, comp)
+    #     print()
+    #     print(f"Forecasting {term}...")
+    #     jump(term,steps)
+    #     print()
+
+    dino_data = [
+        ("ssh", "DINO_1m_To_1y_grid_T.nc"),
+        ("soce", "DINO_1y_grid_T.nc"),
+        ("toce", "DINO_1y_grid_T.nc"),
+    ]
+
+    for term in dino_data:
+        print(f"Preparing {term[0]}...")
+        prepare(term, simu_path, start, end, ye, comp)
         print()
-        print(f"Forecasting {term}...")
-        jump(term,steps)
+        print(f"Forecasting {term[0]}...")
+        jump(term[0], steps)
         print()
 
-if __name__ == '__main__':
 
-    #simu_path = "/scratchu/mtissot/SIMUp6Y"                                                            
+if __name__ == "__main__":
+    # simu_path = "/scratchu/mtissot/SIMUp6Y"
     parser = argparse.ArgumentParser(description="Emulator")
-    parser.add_argument("--path",  type=str,   help= "Enter the simulation pathn")                           #Path
-    parser.add_argument("--ye",    type=bool,  help= "Transform monthly simulation to yearly simulation")    #Transform monthly simulation to yearly simulation
-    parser.add_argument("--start", type=int,   help = "Start of the training")                               #Start of the simu : 0 to keep spin up / t to cut the spin up
-    parser.add_argument("--end",   type=int,   help = "End of the training")                                 #End of the simu  (end-strat = train len)
-    parser.add_argument("--steps", type=int,   help = "Number of steps to emulate")                          #Number of years you want to forecast
-    parser.add_argument("--comp",  type=float, help="Explained variance ratio for the pca")                  #Explained variance ratio for the pca
+    parser.add_argument("--path", type=str, help="Enter the simulation pathn")  # Path
+    parser.add_argument(
+        "--ye", type=bool, help="Transform monthly simulation to yearly simulation"
+    )  # Transform monthly simulation to yearly simulation
+    parser.add_argument(
+        "--start", type=int, help="Start of the training"
+    )  # Start of the simu : 0 to keep spin up / t to cut the spin up
+    parser.add_argument(
+        "--end", type=int, help="End of the training"
+    )  # End of the simu  (end-strat = train len)
+    parser.add_argument(
+        "--steps", type=int, help="Number of steps to emulate"
+    )  # Number of years you want to forecast
+    parser.add_argument(
+        "--comp", type=str, help="Explained variance ratio for the pca"
+    )  # Explained variance ratio for the pca
     args = parser.parse_args()
 
-    emulate(simu_path=args.path,steps=args.steps,ye=args.ye,start=args.start,end=args.end,comp=args.comp)
+    # converts comp to int or float if possible
+    if args.comp.isdigit():
+        args.comp = int(args.comp)
+    elif args.comp.replace(".", "", 1).isdigit():
+        args.comp = float(args.comp)
+    elif args.comp == "None":
+        args.comp = None
 
-    #update_restart_files
-    
-    #python SpinUp/jumper/main/main_forecast.py --ye True --start 25 --end 65 --comp 0.9 --steps 30 --path /scratchu/mtissot/SIMUp6Y
+    emulate(
+        simu_path=args.path,
+        steps=args.steps,
+        ye=args.ye,
+        start=args.start,
+        end=args.end,
+        comp=args.comp,
+    )
+
+    # update_restart_files
+
+    # python SpinUp/jumper/main/main_forecast.py --ye True --start 25 --end 65 --comp 0.9 --steps 30 --path /scratchu/mtissot/SIMUp6Y

--- a/main_forecast.py
+++ b/main_forecast.py
@@ -10,73 +10,98 @@ sys.path.insert(0, "./lib/")
 from forecast import Predictions, Simulation, load_ts
 
 
-file_simu_prepared = "/rds/project/rds-5mCMIDBOkPU/ma595/nemo/NEMO/nemo_4.2.1/tests/DINO/concatenate_grid_150/simus_prepared_2"
-file_simu_predicted = "/rds/project/rds-5mCMIDBOkPU/ma595/nemo/NEMO/nemo_4.2.1/tests/DINO/concatenate_grid_150/simus_predicted_2"
-
-
 def prepare(term, simu_path, start, end, ye, comp):
     """
     Prepare the simulation for the forecast
 
     Args:
-    term (str): term to forecast
-    simu_path (str): path to the simulation
-    start (int): start of the simulation
-    end (int): end of the simulation
-    ye (bool): transform monthly simulation to yearly simulation
-    comp (int or float): explained variance ratio for the pcaA
+        term (str): term to forecast
+        simu_path (str): path to the simulation
+        start (int): start of the simulation
+        end (int): end of the simulation
+        ye (bool): transform monthly simulation to yearly simulation
+        comp (int or float): explained variance ratio for the pcaA
 
     Returns:
-    None
+        None
 
     """
-    simu = Simulation(
-        path=simu_path, start=start, end=end, ye=ye, comp=comp, term=term
-    )  # Load yearly or monthly simulations
+
+    # Load yearly or monthly simulations
+    simu = Simulation(path=simu_path, start=start, end=end, ye=ye, comp=comp, term=term)
     print(f"{term[0]} loaded")
-    simu.prepare()  # Prepare simulations : start to end - removeClosedSeas - (removeSSCA) - standardize - to numpy
+
+    # Prepare simulations : start to end - removeClosedSeas - (removeSSCA) - standardize - to numpy
+    simu.prepare()
     print(f"{term[0]} prepared")
-    simu.applyPCA()  # Exctract time series through PCA
+
+    # Exctract time series through PCA
+    simu.applyPCA()
     print(f"PCA applied on {term[0]}")
 
-    os.makedirs(f'{file_simu_prepared}/{term[0]}', exist_ok=True)
+    os.makedirs(f"{simu_path}/simu_prepared/{term[0]}", exist_ok=True)
+    print(f"{simu_path}/simu_prepared/{term[0]} created")
 
-    print(f'{file_simu_prepared}/{term[0]}')
-
-    simu.save(
-        file_simu_prepared, term[0]
-    )  # Create dico and save: time series - mask - desc -(ssca) - cut(=start) - x_size - y_size - (z_size) - shape
-    print(f"{term[0]} saved at {file_simu_prepared}/{term[0]}")
-    del simu  # Clean RAM
+    # Create dictionary and save:
+    # time series - mask - desc -(ssca) - cut(=start) - x_size - y_size - (z_size) - shape
+    simu.save(f"{simu_path}/simu_prepared", term[0])
+    print(f"{term[0]} saved at {simu_path}/simu_repared/{term[0]}")
 
 
-def jump(term, steps):
+def jump(simu_path, term, steps):
+    """
+    Forecast the simulation
+
+    Args:
+        simu_path (str): path to the simulation
+        term (str): term to forecast
+        steps (int): number of years to forecast
+
+    Returns:
+        None
+
+    """
+
     df, infos = load_ts(
-        f"{file_simu_prepared}/{term}", term
+        f"{simu_path}/simu_prepared/{term}", term
     )  # load dataframe and infos
-    simu_ts = Predictions(term, df, infos)  # create the class to predict
+
+    # Create instance of prediction class
+    simu_ts = Predictions(term, df, infos)
     print(f"{term} time series loaded")
-    y_hat, y_hat_std, metrics = simu_ts.Forecast(len(simu_ts), steps)  # Forecast
+
+    # Forecast
+    y_hat, y_hat_std, metrics = simu_ts.Forecast(len(simu_ts), steps)
     print(f"{term} time series forcasted")
-    n = len(simu_ts.info["pca"].components_)  # Reconstruct n predicted components
+
+    # Reconstruct n predicted components
+    n = len(simu_ts.info["pca"].components_)
     predictions_zos = simu_ts.reconstruct(y_hat, n, begin=len(simu_ts))
     print(f"{term} predictions reconstructed")
 
-    os.makedirs(f'{file_simu_predicted}/{term[0]}', exist_ok=True)
-    np.save(f"{file_simu_predicted}/{term}.npy", predictions_zos)  # Save
-    print(f"{term} predictions saved at {file_simu_predicted}")
-    del simu_ts
+    os.makedirs(f"{simu_path}/simu_predicted/", exist_ok=True)
+    np.save(f"{simu_path}/simu_predicted/{term}.npy", predictions_zos)  # Save
+    print(f"{term} predictions saved at {simu_path}/simu_predicted/{term}.npy")
 
 
 def emulate(simu_path, steps, ye, start, end, comp):
-    # for term in ["zos","so","thetao"]:
-    #     print(f"Preparing {term}...")
-    #     prepare(term,simu_path, ye, start, end, comp)
-    #     print()
-    #     print(f"Forecasting {term}...")
-    #     jump(term,steps)
-    #     print()
+    """
+    Emulate the forecast
 
+    Args:
+        simu_path (str): path to the simulation
+        steps (int): number of years to forecast
+        ye (bool): transform monthly simulation to yearly simulation
+        start (int): start of the simulation
+        end (int): end of the simulation
+        comp (int or float): explained variance ratio for the pca
+
+    Returns:
+        None
+
+    """
+
+    # TODO: Load data from config / json file.
     dino_data = [
         ("ssh", "DINO_1m_To_1y_grid_T.nc"),
         ("soce", "DINO_1y_grid_T.nc"),
@@ -93,9 +118,15 @@ def emulate(simu_path, steps, ye, start, end, comp):
 
 
 if __name__ == "__main__":
-    # simu_path = "/scratchu/mtissot/SIMUp6Y"
+    # Perform forecast
+
+    # Example use
+    # python main_forecast.py --ye True --start 25 --end 65 --comp 0.9 --steps 30 --path /path/to/simu/data
+
     parser = argparse.ArgumentParser(description="Emulator")
-    parser.add_argument("--path", type=str, help="Enter the simulation pathn")  # Path
+    parser.add_argument(
+        "--path", type=str, help="Path to simulation data to forecast from"
+    )
     parser.add_argument(
         "--ye", type=bool, help="Transform monthly simulation to yearly simulation"
     )  # Transform monthly simulation to yearly simulation
@@ -113,7 +144,7 @@ if __name__ == "__main__":
     )  # Explained variance ratio for the pca
     args = parser.parse_args()
 
-    # converts comp to int or float if possible
+    # Convert comp to int or float if possible
     if args.comp.isdigit():
         args.comp = int(args.comp)
     elif args.comp.replace(".", "", 1).isdigit():
@@ -129,7 +160,3 @@ if __name__ == "__main__":
         end=args.end,
         comp=args.comp,
     )
-
-    # update_restart_files
-
-    # python SpinUp/jumper/main/main_forecast.py --ye True --start 25 --end 65 --comp 0.9 --steps 30 --path /scratchu/mtissot/SIMUp6Y

--- a/restart_toolbox.sh
+++ b/restart_toolbox.sh
@@ -1,0 +1,75 @@
+#! /bin/bash
+set -e
+# initial sketch of the restart-toolbox that generates a restart file compatible with NEMO/DINO from:
+
+# Requirements:
+
+# path to simus_predicted
+# path to DINO/NEMO simulation output
+# path to main_restart.py
+# path to REBUILD_NEMO tools.
+
+# TODO: check if absolute path to REBUILD_NEMO has been provided, if not assume below
+
+# TODO: Check if absolute path has been provided to NEMO otherwise assume below
+
+# TODO: number of procs used for sim. (36)
+
+# The following files are found in the job directory
+
+# - path to DINO output containing the following:
+# - 'mask_file_[00**]' : Mask file which masks out areas where the ocean does not exist. Suffixed by processor.
+# - 'DINO_[<time>]_[00**]': Checkpoint or restart file which is indexed by processor
+# I suspect we can easily extract all that we need by just passing in the DINO output directory.
+
+TEST=DINO
+# set path to NEMO
+NEMO=/rds/project/rds-5mCMIDBOkPU/ma595/nemo/NEMO/
+NEMO_4_2_1=$NEMO/nemo_4.2.1
+NEMO_trunk=$NEMO/trunk
+
+output=$NEMO_4_2_1/tests/DINO/notebook-data-50/
+ml_output=$output/simus_predicted
+
+# Further command line arguments
+PROCS=36
+TIME=00576000
+
+RESTART_NAME=${TEST}_${TIME}_restart
+
+# - 'simus_predicted' : ML prediction / jump of T, ssh and salinity obtained from the Jumper notebook
+
+# set up environment
+module purge
+module load rhel8/default-ccl
+module load python/3.11.9/gcc/nptrdpll
+module load netcdf-fortran/4.6.1/intel/intel-oneapi-mpi/kqukipdf
+module load boost/1.85.0/gcc/zouxm6hy
+
+source ./venv3.9/bin/activate
+
+# 1: PATH TO NEMO
+export CPATH=$NEMO/trunk/inc:$CPATH
+export LD_LIBRARY_PATH=$NEMO_trunk/lib:$LD_LIBRARY_PATH
+
+REBUILD_NEMO=${NEMO_4_2_1}/tools/REBUILD_NEMO/rebuild_nemo
+# /rds/project/rds-5mCMIDBOkPU/ma595/nemo/NEMO/nemo_4.2.1/
+
+#2 : Run rebuild_nemo on the mesh_mask files and checkpoint files
+$REBUILD_NEMO -n ./nam_rebuild $output/$RESTART_NAME $PROCS &> out.txt
+$REBUILD_NEMO -n ./nam_rebuild $output/mesh_mask $PROCS &> out.txt
+
+echo "Files recombined in $output as $output/$RESTART_NAME.nc and $output/mesh_mask.nc"
+
+echo "Executing main_restart.py"
+
+#3 : Run main_restart.py to create new restart file
+python main_restart.py \
+  --restart_path $output \
+  --radical $RESTART_NAME \
+  --mask_file $output/mesh_mask.nc \
+  --prediction_path $ml_output
+
+# outputs with prefix NEW.
+
+echo "New restart file in $output as $output/NEW_${RESTART_NAME}_restart.nc"

--- a/restart_toolbox.sh
+++ b/restart_toolbox.sh
@@ -1,75 +1,76 @@
 #! /bin/bash
 set -e
-# initial sketch of the restart-toolbox that generates a restart file compatible with NEMO/DINO from:
 
-# Requirements:
-
-# path to simus_predicted
-# path to DINO/NEMO simulation output
-# path to main_restart.py
-# path to REBUILD_NEMO tools.
-
-# TODO: check if absolute path to REBUILD_NEMO has been provided, if not assume below
-
-# TODO: Check if absolute path has been provided to NEMO otherwise assume below
-
-# TODO: number of procs used for sim. (36)
-
-# The following files are found in the job directory
-
-# - path to DINO output containing the following:
-# - 'mask_file_[00**]' : Mask file which masks out areas where the ocean does not exist. Suffixed by processor.
-# - 'DINO_[<time>]_[00**]': Checkpoint or restart file which is indexed by processor
-# I suspect we can easily extract all that we need by just passing in the DINO output directory.
-
+# TODO - command line arguments
 TEST=DINO
-# set path to NEMO
-NEMO=/rds/project/rds-5mCMIDBOkPU/ma595/nemo/NEMO/
-NEMO_4_2_1=$NEMO/nemo_4.2.1
-NEMO_trunk=$NEMO/trunk
-
-output=$NEMO_4_2_1/tests/DINO/notebook-data-50/
-ml_output=$output/simus_predicted
-
-# Further command line arguments
 PROCS=36
 TIME=00576000
 
+if [ -z "$TEST" ] || [ -z "$PROCS" ] || [ -z "$TIME" ]; then
+  echo "Error: One or more required variables (TEST, PROCS, TIME) are not set."
+  exit 1
+fi
+
+# Path to main_restart.py
+# cd to directory where this script is.
+cd "$(dirname "$0")"
+
+# Check if main_restart.py exists
+if [ ! -f "main_restart.py" ]; then
+  echo "Error: main_restart.py not found in the script directory."
+  exit 1
+fi
+
+# Path to NEMO, XIOS and tools
+# This file must be created before the execution of this script (system specific)
+source env.sh
+
+# Check if env.sh exists
+if [ ! -f "env.sh" ]; then
+  echo "Error: env.sh not found containing, REBUILD_NEMO/rebuild_nemo, nemo_output_dir or ml_prediction_dir."
+  exit 1
+fi
+
+# Check if REBUILD_NEMO is set and executable, OR if `rebuild_nemo` is in PATH
+if [ -n "$REBUILD_NEMO" ] && [ -x "$REBUILD_NEMO" ] || command -v rebuild_nemo &>/dev/null; then
+  echo "REBUILD_NEMO is set correctly or available in PATH."
+else
+  echo "Error: REBUILD_NEMO is not set to an executable file and 'rebuild_nemo' is not found in PATH."
+  exit 1
+fi
+
+# Check if output directories set
+if [ -n "$nemo_output_dir" ] && [ -n "$ml_prediction_dir" ]; then
+  echo "Output directories set"
+else
+  echo "One of nemo_output_dir or ml_prediction_dir not correctly set"
+  exit 1
+fi
+
+# The following files are found in the job directory
+# - path to simulation output containing the following:
+# - 'mask_file_[00**]' : Mask file which masks out areas where the ocean does not exist, suffixed by processor.
+# - '$TEST_[<time>]_[00**]': Checkpoint/restart file, suffixed by processor.
+
 RESTART_NAME=${TEST}_${TIME}_restart
 
-# - 'simus_predicted' : ML prediction / jump of T, ssh and salinity obtained from the Jumper notebook
 
-# set up environment
-module purge
-module load rhel8/default-ccl
-module load python/3.11.9/gcc/nptrdpll
-module load netcdf-fortran/4.6.1/intel/intel-oneapi-mpi/kqukipdf
-module load boost/1.85.0/gcc/zouxm6hy
+# 2: Combine files
+# this combines all files indexed by $PROCS into a single file.
+$REBUILD_NEMO -n ./nam_rebuild $nemo_output_dir/$RESTART_NAME $PROCS &> out.txt
+$REBUILD_NEMO -n ./nam_rebuild $nemo_output_dir/mesh_mask $PROCS &> out.txt
 
-source ./venv3.9/bin/activate
-
-# 1: PATH TO NEMO
-export CPATH=$NEMO/trunk/inc:$CPATH
-export LD_LIBRARY_PATH=$NEMO_trunk/lib:$LD_LIBRARY_PATH
-
-REBUILD_NEMO=${NEMO_4_2_1}/tools/REBUILD_NEMO/rebuild_nemo
-# /rds/project/rds-5mCMIDBOkPU/ma595/nemo/NEMO/nemo_4.2.1/
-
-#2 : Run rebuild_nemo on the mesh_mask files and checkpoint files
-$REBUILD_NEMO -n ./nam_rebuild $output/$RESTART_NAME $PROCS &> out.txt
-$REBUILD_NEMO -n ./nam_rebuild $output/mesh_mask $PROCS &> out.txt
-
-echo "Files recombined in $output as $output/$RESTART_NAME.nc and $output/mesh_mask.nc"
+echo "Files recombined in $output as $nemo_output_dir/$RESTART_NAME.nc and $nemo_output_dir/mesh_mask.nc"
 
 echo "Executing main_restart.py"
 
-#3 : Run main_restart.py to create new restart file
+# 3: Run main_restart.py to create new restart file
 python main_restart.py \
-  --restart_path $output \
+  --restart_path $nemo_output_dir \
   --radical $RESTART_NAME \
-  --mask_file $output/mesh_mask.nc \
-  --prediction_path $ml_output
+  --mask_file $nemo_output_dir/mesh_mask.nc \
+  --prediction_path $ml_prediction_dir
 
 # outputs with prefix NEW.
 
-echo "New restart file in $output as $output/NEW_${RESTART_NAME}_restart.nc"
+echo "New restart file in $nemo_output_dir as $nemo_output_dir/NEW_${RESTART_NAME}_restart.nc"


### PR DESCRIPTION
Some minor changes to the restart pipeline description within the README.md. 

- [x] Simple restart toolbox script #33
- [x] Modify main_forecast.py so that it's compatible with DINO data and add docstring / improve structure. 
- [x] Make forecast deterministic given some random seed.

Before commiting 
- Merge this PR into #30 before rebasing that PR. 
- Consider moving pipeline instructions out the README.md and making a separate `Restart_Toolbox.md`

