### PR TITLE
Fix forecasting bugs

### DIFF
--- a/src/nemo_spinup_forecast/forecast.py
+++ b/src/nemo_spinup_forecast/forecast.py
@@ -640,7 +640,7 @@ class Predictions:
         y_test = None
         if train_len < len(self):
             y_test = (
-                self.data[self.var + "-" + str(1)].iloc[train_len : len(self)].to_numpy()
+                self.data[self.var + "-" + str(n)].iloc[train_len : len(self)].to_numpy()
             )
         return mean, std, y_train, y_test, x_train, x_pred
 

--- a/src/nemo_spinup_forecast/forecast_method.py
+++ b/src/nemo_spinup_forecast/forecast_method.py
@@ -163,7 +163,7 @@ class RecursiveForecaster(BaseForecaster):
         self.window_size = window_size
         self.steps = steps
 
-    def apply_forecast(self, y_train):
+    def apply_forecast(self, y_train, _x_train, _x_pred):
         """
         Fit a recursive forecaster using the provided regressor.
 
@@ -171,9 +171,9 @@ class RecursiveForecaster(BaseForecaster):
         ----------
         y_train : array-like
             Training target series.
-        x_train : array-like, optional
+        _x_train : array-like, optional
             Not used directly in this recursive implementation.
-        x_pred : array-like, optional
+        _x_pred : array-like, optional
             Not used directly in this recursive implementation.
 
         Returns


### PR DESCRIPTION
## Change Description

`y_test` was always set to be the first component rather than being parameterised by `n`.

The function signature for apply_forecast in the RecursiveForecast class was missing `x_train` and `x_pred` parameters.

## Task List

- [x] Parameterise y_test by `n`
- [x] Add missing parameters `x_train` and `x_pred` 

Closes #97 