### PR TITLE
Improve plotting functions for examples

### DIFF
--- a/Notebooks/Jumper.ipynb
+++ b/Notebooks/Jumper.ipynb
@@ -757,7 +757,7 @@
     "colors = [\"tab:blue\", \"tab:green\", \"tab:red\"]\n",
     "total_len = len(ref_list[0].simulation)\n",
     "\n",
-    "plot_component_timeseries(ref_list, pred, names, colors, comp, total_len);"
+    "plot_component_timeseries(ref_list, pred, names, colors, comp, total_len, train_len);"
    ]
   },
   {
@@ -769,7 +769,7 @@
    "source": [
     "comp = 1\n",
     "\n",
-    "plot_component_timeseries(ref_list, pred, names, colors, comp, total_len);"
+    "plot_component_timeseries(ref_list, pred, names, colors, comp, total_len, train_len);"
    ]
   },
   {
@@ -781,7 +781,7 @@
    "source": [
     "comp = 2\n",
     "\n",
-    "plot_component_timeseries(ref_list, pred, names, colors, comp, total_len);"
+    "plot_component_timeseries(ref_list, pred, names, colors, comp, total_len, train_len);"
    ]
   }
  ],

--- a/Notebooks/Jumper.ipynb
+++ b/Notebooks/Jumper.ipynb
@@ -53,7 +53,6 @@
     "    plot_component_timeseries,\n",
     "    plot_depth_error_profiles,\n",
     "    plot_depth_prediction_reference,\n",
-    "    plot_mean_profiles,\n",
     "    plot_pca_diagnostics,\n",
     "    plot_reconstructions,\n",
     "    plot_rmse_depth_profile,\n",
@@ -304,13 +303,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "values = [rmseVs[\"zos\"], rmseVs[\"so\"].T, rmseVs[\"thetao\"].T]\n",
     "maps = [rmseMs[\"zos\"], rmseMs[\"so\"], rmseMs[\"thetao\"]]\n",
     "names = [ssh_term, so_term, thetao_term]\n",
     "colors = [\"tab:blue\", \"darkgreen\", \"darkred\"]\n",
-    "# SSH has no depth axis; it is plotted as a single surface point.\n",
+    "# Only 4D variables (so, thetao) have a depth axis; SSH is excluded.\n",
     "plot_rmse_depth_profile(\n",
-    "    values, array.deptht, names, colors, \"PCA EVALUATION - 1st COMP\"\n",
+    "    [rmseVs[\"so\"].T, rmseVs[\"thetao\"].T],\n",
+    "    array.deptht,\n",
+    "    [so_term, thetao_term],\n",
+    "    [\"darkgreen\", \"darkred\"],\n",
+    "    \"PCA EVALUATION - 1st COMP\",\n",
     ");"
    ]
   },
@@ -698,22 +700,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb091797-b6a3-40b7-ab94-d5388277fd8c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mean_pred_list = [mean_pred[\"zos\"], mean_pred[\"so\"], mean_pred[\"thetao\"]]\n",
-    "mean_ref_list = [mean_ref[\"zos\"], mean_ref[\"so\"], mean_ref[\"thetao\"]]\n",
-    "names = [\"zos\", \"so\", \"thetao\"]\n",
-    "colors = [\"tab:blue\", \"darkgreen\", \"darkred\"]\n",
-    "\n",
-    "# Plot mean profiles for all terms using the arrays computed above.\n",
-    "plot_mean_profiles(mean_pred_list, mean_ref_list, names, colors);"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "2c99115f-afdd-4104-b4a1-73a37686f426",
    "metadata": {},
@@ -797,14 +783,6 @@
     "\n",
     "plot_component_timeseries(ref_list, pred, names, colors, comp, total_len);"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8725d188",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/nemo_spinup_forecast/forecast.py
+++ b/src/nemo_spinup_forecast/forecast.py
@@ -692,6 +692,8 @@ class Predictions:
             alpha=0.2,
         )
         plt.title(f"parallel_forecast of {self.var} {n!s}")
+        plt.xlabel("Time step")
+        plt.ylabel(f"Component value")
         plt.legend()
         plt.show()
         print()

--- a/src/nemo_spinup_forecast/plotting_utils.py
+++ b/src/nemo_spinup_forecast/plotting_utils.py
@@ -61,6 +61,8 @@ def plot_pca_diagnostics(simus: Sequence, names: Sequence[str], colors: Sequence
     for i, simu in enumerate(simus):
         axes[0, i].plot(simu.pca.explained_variance_ratio_ * 100, "ko", markersize=4)
         axes[0, i].set_title(f"Explained Variance Ratio - {names[i]}")
+        axes[0, i].set_xlabel("Component")
+        axes[0, i].set_ylabel("Variance (%)")
 
         axes[1, i].plot(
             simu.components[:, 0], color=colors[i], alpha=0.9, label="1st comp"
@@ -69,6 +71,8 @@ def plot_pca_diagnostics(simus: Sequence, names: Sequence[str], colors: Sequence
             simu.components[:, 1], color=colors[i], alpha=0.4, label="2nd comp"
         )
         axes[1, i].set_title(f"Components - {names[i]}")
+        axes[1, i].set_xlabel("Time step (year)")
+        axes[1, i].set_ylabel("Component value")
         axes[1, i].legend()
 
         if simu.z_size is not None:
@@ -81,6 +85,7 @@ def plot_pca_diagnostics(simus: Sequence, names: Sequence[str], colors: Sequence
             axes[2, i].set_title(f"1st PC - {names[i]}")
 
     fig.suptitle("PCA INFO")
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
     plt.show()
     return fig, axes
 
@@ -119,7 +124,7 @@ def plot_rmse_depth_profile(
     """
     fig, ax = plt.subplots(figsize=(6, 8))
     for val, name, color in zip(values, names, colors, strict=True):
-        plt.errorbar(
+        ax.errorbar(
             np.mean(val, axis=1),
             depth,
             xerr=np.std(val, axis=1),
@@ -129,11 +134,11 @@ def plot_rmse_depth_profile(
             ecolor="grey",
         )
 
-    plt.title(title)
-    plt.ylabel("Depth")
-    plt.xlabel("RMSE")
-    plt.legend()
-    plt.gca().invert_yaxis()
+    ax.set_title(title)
+    ax.set_ylabel("Depth (m)")
+    ax.set_xlabel("RMSE")
+    ax.legend()
+    ax.invert_yaxis()
     plt.show()
     return fig, ax
 
@@ -209,6 +214,7 @@ def plot_bar_with_errors(
     errors: Sequence[float],
     title: str,
     ylabel: str,
+    colors: Sequence[str] | None = None,
 ):
     """
     Plot a bar chart with error bars.
@@ -225,14 +231,18 @@ def plot_bar_with_errors(
         Title for the plot.
     ylabel : str
         Y-axis label.
+    colors : sequence of str, optional
+        Colors for each bar. Defaults to the matplotlib colour cycle.
 
     Returns
     -------
     tuple
         Matplotlib ``(fig, ax)``.
     """
+    if colors is None:
+        colors = [f"C{i}" for i in range(len(categories))]
     fig, ax = plt.subplots(figsize=(6, 3))
-    ax.bar(categories, means, yerr=errors, capsize=5, color=["tab:blue", "grey"])
+    ax.bar(categories, means, yerr=errors, capsize=5, color=colors)
 
     ax.set_title(title)
     ax.set_ylabel(ylabel)
@@ -286,7 +296,7 @@ def plot_depth_error_profiles(
             depth,
             mean_ref[i],
             color="black",
-            label=label,
+            label=f"{label} ref",
             linestyle="dashed",
             alpha=0.6,
         )
@@ -298,7 +308,7 @@ def plot_depth_error_profiles(
             alpha=0.1,
         )
 
-        axes[i].plot(depth, mean_pred[i], color=colors[i], label=label)
+        axes[i].plot(depth, mean_pred[i], color=colors[i], label=f"{label} pred")
         axes[i].fill_between(
             depth,
             mean_pred[i] + std_pred[i],
@@ -306,12 +316,12 @@ def plot_depth_error_profiles(
             color=colors[i],
             alpha=0.2,
         )
-        axes[i].set_xlabel("Depth")
+        axes[i].set_xlabel("Depth (m)")
         axes[i].set_ylabel("Mean Error")
         axes[i].legend()
 
     fig.suptitle(title)
-    plt.tight_layout()
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
     plt.show()
     return fig, axes
 
@@ -321,6 +331,7 @@ def plot_depth_prediction_reference(
     mean_pred: Sequence[np.ndarray],
     mean_ref: Sequence[np.ndarray],
     titles: Sequence[str],
+    ylabel: str = "",
 ):
     """
     Plot prediction vs reference profiles for multiple variables.
@@ -335,6 +346,8 @@ def plot_depth_prediction_reference(
         Reference mean profiles per variable.
     titles : sequence of str
         Titles for each subplot.
+    ylabel : str, optional
+        Y-axis label (e.g. the variable units). Defaults to no label.
 
     Returns
     -------
@@ -348,9 +361,13 @@ def plot_depth_prediction_reference(
         ax.plot(depth, pred, label="predictions")
         ax.plot(depth, ref, label="reference")
         ax.set_title(title)
+        ax.set_xlabel("Depth (m)")
+        if ylabel:
+            ax.set_ylabel(ylabel)
         ax.legend()
 
     fig.suptitle("Average over depth")
+    plt.tight_layout(rect=[0, 0, 1, 0.95])
     plt.show()
     return fig, axes
 
@@ -362,6 +379,7 @@ def plot_component_timeseries(
     colors: Sequence[str],
     comp: int,
     total_len: int,
+    steps_per_year: int = 1,
 ):
     """
     Plot component time series for reference and predicted data.
@@ -380,6 +398,9 @@ def plot_component_timeseries(
         Component index to plot.
     total_len : int
         Length for the x-axis.
+    steps_per_year : int, optional
+        Number of time steps per year, used to set x-axis tick spacing.
+        Default is 1 (yearly data).
 
     Returns
     -------
@@ -401,7 +422,11 @@ def plot_component_timeseries(
             label=name,
         )
         ax.set_title(f"Components - {name}")
+        ax.set_xlabel("Time step (year)")
+        ax.set_ylabel("Component value")
+        ax.set_xticks(range(0, total_len, steps_per_year))
         ax.legend()
     fig.suptitle("PCA INFO")
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
     plt.show()
     return fig, axes

--- a/src/nemo_spinup_forecast/plotting_utils.py
+++ b/src/nemo_spinup_forecast/plotting_utils.py
@@ -160,14 +160,10 @@ def plot_rmse_maps(maps: Sequence[np.ndarray], names: Sequence[str]):
     axes = axes.flatten()
 
     for ax, rmse_map, name in zip(axes, maps, names, strict=True):
-        if len(np.shape(rmse_map)) == 2:
-            im = ax.pcolormesh(rmse_map)
-            plt.colorbar(im, ax=ax)
-            ax.set_title(f"Mean rmse map - {name}")
-        else:
-            im = ax.pcolormesh(np.nanmean(rmse_map, axis=0))
-            plt.colorbar(im, ax=ax)
-            ax.set_title(f"Mean rmse map - {name}")
+        data = rmse_map if len(np.shape(rmse_map)) == 2 else np.nanmean(rmse_map, axis=0)
+        im = ax.pcolormesh(data)
+        plt.colorbar(im, ax=ax)
+        ax.set_title(f"Mean rmse map - {name}")
 
     plt.tight_layout()
     plt.show()
@@ -214,6 +210,7 @@ def plot_bar_with_errors(
     title: str,
     ylabel: str,
     colors: Sequence[str] | None = None,
+    xlabel: str = "Categories",
 ):
     """
     Plot a bar chart with error bars.
@@ -232,6 +229,8 @@ def plot_bar_with_errors(
         Y-axis label.
     colors : sequence of str, optional
         Colors for each bar. Defaults to the matplotlib colour cycle.
+    xlabel : str, optional
+        X-axis label. Defaults to ``"Categories"``.
 
     Returns
     -------
@@ -245,7 +244,7 @@ def plot_bar_with_errors(
 
     ax.set_title(title)
     ax.set_ylabel(ylabel)
-    ax.set_xlabel("Categories")
+    ax.set_xlabel(xlabel)
     plt.show()
     return fig, ax
 

--- a/src/nemo_spinup_forecast/plotting_utils.py
+++ b/src/nemo_spinup_forecast/plotting_utils.py
@@ -27,13 +27,14 @@ def plot_simulation_snapshots(simus: Sequence, names: Sequence[str]):
 
     for ax, simu, name in zip(axes, simus, names, strict=True):
         if simu.z_size is not None:
-            im = ax.pcolor(simu.simulation[0, 0])
+            im = ax.pcolormesh(simu.simulation[0, 0])
             ax.set_title(f"Surface {name}")
         else:
-            im = ax.pcolor(simu.simulation[0])
+            im = ax.pcolormesh(simu.simulation[0])
             ax.set_title(f"{name}")
         plt.colorbar(im, ax=ax)
 
+    plt.tight_layout()
     plt.show()
     return fig, axes
 
@@ -58,31 +59,27 @@ def plot_pca_diagnostics(simus: Sequence, names: Sequence[str], colors: Sequence
     """
     fig, axes = plt.subplots(3, len(simus), figsize=(20, 10), squeeze=False)
 
-    for i, simu in enumerate(simus):
+    for i, (simu, name, color) in enumerate(zip(simus, names, colors, strict=True)):
         axes[0, i].plot(simu.pca.explained_variance_ratio_ * 100, "ko", markersize=4)
-        axes[0, i].set_title(f"Explained Variance Ratio - {names[i]}")
+        axes[0, i].set_title(f"Explained Variance Ratio - {name}")
         axes[0, i].set_xlabel("Component")
         axes[0, i].set_ylabel("Variance (%)")
 
-        axes[1, i].plot(
-            simu.components[:, 0], color=colors[i], alpha=0.9, label="1st comp"
-        )
-        axes[1, i].plot(
-            simu.components[:, 1], color=colors[i], alpha=0.4, label="2nd comp"
-        )
-        axes[1, i].set_title(f"Components - {names[i]}")
+        axes[1, i].plot(simu.components[:, 0], color=color, alpha=0.9, label="1st comp")
+        axes[1, i].plot(simu.components[:, 1], color=color, alpha=0.4, label="2nd comp")
+        axes[1, i].set_title(f"Components - {name}")
         axes[1, i].set_xlabel("Time step (year)")
         axes[1, i].set_ylabel("Component value")
         axes[1, i].legend()
 
         if simu.z_size is not None:
-            im = axes[2, i].pcolor(simu.get_component(0)[0])
+            im = axes[2, i].pcolormesh(simu.get_component(0)[0])
             plt.colorbar(im, ax=axes[2, i])
-            axes[2, i].set_title(f"1st PC of the surface - {names[i]}")
+            axes[2, i].set_title(f"1st PC of the surface - {name}")
         else:
-            im = axes[2, i].pcolor(simu.get_component(0))
+            im = axes[2, i].pcolormesh(simu.get_component(0))
             plt.colorbar(im, ax=axes[2, i])
-            axes[2, i].set_title(f"1st PC - {names[i]}")
+            axes[2, i].set_title(f"1st PC - {name}")
 
     fig.suptitle("PCA INFO")
     plt.tight_layout(rect=[0, 0, 1, 0.96])
@@ -164,14 +161,15 @@ def plot_rmse_maps(maps: Sequence[np.ndarray], names: Sequence[str]):
 
     for ax, rmse_map, name in zip(axes, maps, names, strict=True):
         if len(np.shape(rmse_map)) == 2:
-            im = ax.pcolor(rmse_map)
+            im = ax.pcolormesh(rmse_map)
             plt.colorbar(im, ax=ax)
             ax.set_title(f"Mean rmse map - {name}")
         else:
-            im = ax.pcolor(np.nanmean(rmse_map, axis=0))
+            im = ax.pcolormesh(np.nanmean(rmse_map, axis=0))
             plt.colorbar(im, ax=ax)
             ax.set_title(f"Mean rmse map - {name}")
 
+    plt.tight_layout()
     plt.show()
     return fig, axes
 
@@ -197,13 +195,14 @@ def plot_reconstructions(maps: Sequence[np.ndarray], names: Sequence[str]):
 
     for ax, simu, name in zip(axes, maps, names, strict=True):
         if len(np.shape(simu)) > 3:
-            im = ax.pcolor(simu[0, 0])
+            im = ax.pcolormesh(simu[0, 0])
             ax.set_title(f"Surface {name}")
         else:
-            im = ax.pcolor(simu[0])
+            im = ax.pcolormesh(simu[0])
             ax.set_title(f"{name}")
         plt.colorbar(im, ax=ax)
 
+    plt.tight_layout()
     plt.show()
     return fig, axes
 

--- a/src/nemo_spinup_forecast/plotting_utils.py
+++ b/src/nemo_spinup_forecast/plotting_utils.py
@@ -377,10 +377,15 @@ def plot_component_timeseries(
     colors: Sequence[str],
     comp: int,
     total_len: int,
+    train_len: int,
     steps_per_year: int = 1,
 ):
     """
     Plot component time series for reference and predicted data.
+
+    The training portion of *pred* (indices ``0`` to ``train_len``) is drawn
+    dashed, while the forecast portion (from ``train_len`` onward) is drawn
+    solid, so the viewer can immediately see where the prediction begins.
 
     Parameters
     ----------
@@ -396,6 +401,10 @@ def plot_component_timeseries(
         Component index to plot.
     total_len : int
         Length for the x-axis.
+    train_len : int
+        Number of initial time steps that belong to the training window.
+        Must match the value used in :func:`forecast_all` to concatenate
+        training data with the forecast.
     steps_per_year : int, optional
         Number of time steps per year, used to set x-axis tick spacing.
         Default is 1 (yearly data).
@@ -412,12 +421,23 @@ def plot_component_timeseries(
         axes, ref, pred, names, colors, strict=True
     ):
         ax.plot(simu.components[:, comp], color="grey", linestyle="dashed", label="ref")
+        # Training segment (dashed) — original data, not predicted.
         ax.plot(
-            np.arange(0, total_len),
-            pred_item.iloc[:, comp],
+            np.arange(0, train_len),
+            pred_item.iloc[:train_len, comp],
             color=color,
             alpha=0.9,
-            label=name,
+            linestyle="dashed",
+            label=f"{name} (training)",
+        )
+        # Forecast segment (solid) — actual model prediction.
+        # Overlap by 1 point so the two segments connect visually.
+        ax.plot(
+            np.arange(train_len - 1, total_len),
+            pred_item.iloc[train_len - 1 :, comp],
+            color=color,
+            alpha=0.9,
+            label=f"{name} (forecast)",
         )
         ax.set_title(f"Components - {name}")
         ax.set_xlabel("Time step (year)")

--- a/src/nemo_spinup_forecast/plotting_utils.py
+++ b/src/nemo_spinup_forecast/plotting_utils.py
@@ -95,10 +95,14 @@ def plot_rmse_depth_profile(
     """
     Plot RMSE error bars versus depth.
 
+    Expects only 4D variables (depth profiles). Do not pass 3D variables such
+    as SSH; each entry in ``values`` must have shape ``(depth, time)`` after
+    any required transposition.
+
     Parameters
     ----------
     values : sequence of ndarray
-        RMSE values for each variable.
+        RMSE values for each variable, each with shape ``(depth, time)``.
     depth : array-like
         Depth coordinates (e.g., ``array.deptht``).
     names : sequence of str
@@ -114,27 +118,16 @@ def plot_rmse_depth_profile(
         Matplotlib ``(fig, ax)``.
     """
     fig, ax = plt.subplots(figsize=(6, 8))
-    for i, (val, name, color) in enumerate(zip(values, names, colors, strict=True)):
-        if i == 0:
-            plt.errorbar(
-                np.mean(val),
-                depth[0],
-                xerr=np.std(val),
-                fmt=".",
-                label=name,
-                color=color,
-                ecolor="grey",
-            )
-        else:
-            plt.errorbar(
-                np.mean(val, axis=1),
-                depth,
-                xerr=np.std(val, axis=1),
-                fmt=".",
-                label=name,
-                color=color,
-                ecolor="grey",
-            )
+    for val, name, color in zip(values, names, colors, strict=True):
+        plt.errorbar(
+            np.mean(val, axis=1),
+            depth,
+            xerr=np.std(val, axis=1),
+            fmt=".",
+            label=name,
+            color=color,
+            ecolor="grey",
+        )
 
     plt.title(title)
     plt.ylabel("Depth")
@@ -358,46 +351,6 @@ def plot_depth_prediction_reference(
         ax.legend()
 
     fig.suptitle("Average over depth")
-    plt.show()
-    return fig, axes
-
-
-def plot_mean_profiles(
-    mean_pred: Sequence[np.ndarray],
-    mean_ref: Sequence[np.ndarray],
-    names: Sequence[str],
-    colors: Sequence[str],
-):
-    """
-    Plot mean profiles for predictions and references.
-
-    Parameters
-    ----------
-    mean_pred : sequence of ndarray
-        Predicted mean profiles.
-    mean_ref : sequence of ndarray
-        Reference mean profiles.
-    names : sequence of str
-        Labels for each variable.
-    colors : sequence of str
-        Colors for each variable.
-
-    Returns
-    -------
-    tuple
-        Matplotlib ``(fig, axes)``.
-    """
-    fig, axes = plt.subplots(len(mean_pred), 1, figsize=(10, 8), squeeze=False)
-    axes = axes.flatten()
-    for ax, pred, ref, name, color in zip(
-        axes, mean_pred, mean_ref, names, colors, strict=True
-    ):
-        ax.plot(pred, color=color, label=name)
-        ax.plot(ref, color="grey", label="ref", linestyle="dashed")
-        ax.set_title(f"Mean profiles - {name}")
-        ax.legend()
-
-    plt.tight_layout()
     plt.show()
     return fig, axes
 

--- a/src/nemo_spinup_forecast/plotting_utils.py
+++ b/src/nemo_spinup_forecast/plotting_utils.py
@@ -33,6 +33,8 @@ def plot_simulation_snapshots(simus: Sequence, names: Sequence[str]):
             im = ax.pcolormesh(simu.simulation[0])
             ax.set_title(f"{name}")
         plt.colorbar(im, ax=ax)
+        ax.set_xlabel("x (grid index)")
+        ax.set_ylabel("y (grid index)")
 
     plt.tight_layout()
     plt.show()
@@ -80,6 +82,8 @@ def plot_pca_diagnostics(simus: Sequence, names: Sequence[str], colors: Sequence
             im = axes[2, i].pcolormesh(simu.get_component(0))
             plt.colorbar(im, ax=axes[2, i])
             axes[2, i].set_title(f"1st PC - {name}")
+        axes[2, i].set_xlabel("x (grid index)")
+        axes[2, i].set_ylabel("y (grid index)")
 
     fig.suptitle("PCA INFO")
     plt.tight_layout(rect=[0, 0, 1, 0.96])
@@ -164,6 +168,8 @@ def plot_rmse_maps(maps: Sequence[np.ndarray], names: Sequence[str]):
         im = ax.pcolormesh(data)
         plt.colorbar(im, ax=ax)
         ax.set_title(f"Mean rmse map - {name}")
+        ax.set_xlabel("x (grid index)")
+        ax.set_ylabel("y (grid index)")
 
     plt.tight_layout()
     plt.show()
@@ -197,6 +203,8 @@ def plot_reconstructions(maps: Sequence[np.ndarray], names: Sequence[str]):
             im = ax.pcolormesh(simu[0])
             ax.set_title(f"{name}")
         plt.colorbar(im, ax=ax)
+        ax.set_xlabel("x (grid index)")
+        ax.set_ylabel("y (grid index)")
 
     plt.tight_layout()
     plt.show()

--- a/src/nemo_spinup_forecast/plotting_utils.py
+++ b/src/nemo_spinup_forecast/plotting_utils.py
@@ -6,9 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def plot_simulation_snapshots(
-    simus: Sequence, names: Sequence[str], show_ssca: bool = False
-):
+def plot_simulation_snapshots(simus: Sequence, names: Sequence[str]):
     """
     Plot the first time step for each simulation.
 
@@ -18,8 +16,6 @@ def plot_simulation_snapshots(
         Simulation objects.
     names : sequence of str
         Labels for each simulation.
-    show_ssca : bool, optional
-        Whether to plot the average SSCA curves.
 
     Returns
     -------
@@ -35,18 +31,6 @@ def plot_simulation_snapshots(
         else:
             im = axes[i].pcolor(simu.simulation[0])
             axes[i].set_title(f"{names[i]}")
-        plt.colorbar(im, ax=axes[i])
-
-    if show_ssca:
-        fig, axes = plt.subplots(1, len(simus), figsize=(20, 4))
-
-        for i, simu in enumerate(simus):
-            if simu.z_size is not None:
-                plt.plot(np.mean(simu.desc["ssca"], axis=(1, 2, 3)))
-                axes[i].set_title(f"Average ssca - {names[i]}")
-            else:
-                plt.plot(np.mean(simu.desc["ssca"], axis=(1, 2)))
-                axes[i].set_title(f"Average ssca - {names[i]}")
         plt.colorbar(im, ax=axes[i])
 
     plt.show()

--- a/src/nemo_spinup_forecast/plotting_utils.py
+++ b/src/nemo_spinup_forecast/plotting_utils.py
@@ -22,16 +22,17 @@ def plot_simulation_snapshots(simus: Sequence, names: Sequence[str]):
     tuple
         Matplotlib ``(fig, axes)``.
     """
-    fig, axes = plt.subplots(1, len(simus), figsize=(20, 4))
+    fig, axes = plt.subplots(1, len(simus), figsize=(20, 4), squeeze=False)
+    axes = axes.flatten()
 
-    for i, simu in enumerate(simus):
+    for ax, simu, name in zip(axes, simus, names, strict=True):
         if simu.z_size is not None:
-            im = axes[i].pcolor(simu.simulation[0, 0])
-            axes[i].set_title(f"Surface {names[i]}")
+            im = ax.pcolor(simu.simulation[0, 0])
+            ax.set_title(f"Surface {name}")
         else:
-            im = axes[i].pcolor(simu.simulation[0])
-            axes[i].set_title(f"{names[i]}")
-        plt.colorbar(im, ax=axes[i])
+            im = ax.pcolor(simu.simulation[0])
+            ax.set_title(f"{name}")
+        plt.colorbar(im, ax=ax)
 
     plt.show()
     return fig, axes
@@ -55,7 +56,7 @@ def plot_pca_diagnostics(simus: Sequence, names: Sequence[str], colors: Sequence
     tuple
         Matplotlib ``(fig, axes)``.
     """
-    fig, axes = plt.subplots(3, 3, figsize=(20, 10))
+    fig, axes = plt.subplots(3, len(simus), figsize=(20, 10), squeeze=False)
 
     for i, simu in enumerate(simus):
         axes[0, i].plot(simu.pca.explained_variance_ratio_ * 100, "ko", markersize=4)
@@ -113,25 +114,25 @@ def plot_rmse_depth_profile(
         Matplotlib ``(fig, ax)``.
     """
     fig, ax = plt.subplots(figsize=(6, 8))
-    for i in range(3):
+    for i, (val, name, color) in enumerate(zip(values, names, colors, strict=True)):
         if i == 0:
             plt.errorbar(
-                np.mean(values[i]),
+                np.mean(val),
                 depth[0],
-                xerr=np.std(values[i]),
+                xerr=np.std(val),
                 fmt=".",
-                label=names[i],
-                color=colors[i],
+                label=name,
+                color=color,
                 ecolor="grey",
             )
         else:
             plt.errorbar(
-                np.mean(values[i], axis=1),
+                np.mean(val, axis=1),
                 depth,
-                xerr=np.std(values[i], axis=1),
+                xerr=np.std(val, axis=1),
                 fmt=".",
-                label=names[i],
-                color=colors[i],
+                label=name,
+                color=color,
                 ecolor="grey",
             )
 
@@ -160,17 +161,18 @@ def plot_rmse_maps(maps: Sequence[np.ndarray], names: Sequence[str]):
     tuple
         Matplotlib ``(fig, axes)``.
     """
-    fig, axes = plt.subplots(1, 3, figsize=(20, 5))
+    fig, axes = plt.subplots(1, len(maps), figsize=(20, 5), squeeze=False)
+    axes = axes.flatten()
 
-    for i in range(3):
-        if len(np.shape(maps[i])) == 2:
-            im = axes[i].pcolor(maps[i])
-            plt.colorbar(im, ax=axes[i])
-            axes[i].set_title(f"Mean rmse map - {names[i]}")
+    for ax, rmse_map, name in zip(axes, maps, names, strict=True):
+        if len(np.shape(rmse_map)) == 2:
+            im = ax.pcolor(rmse_map)
+            plt.colorbar(im, ax=ax)
+            ax.set_title(f"Mean rmse map - {name}")
         else:
-            im = axes[i].pcolor(np.nanmean(maps[i], axis=0))
-            plt.colorbar(im, ax=axes[i])
-            axes[i].set_title(f"Mean rmse map - {names[i]}")
+            im = ax.pcolor(np.nanmean(rmse_map, axis=0))
+            plt.colorbar(im, ax=ax)
+            ax.set_title(f"Mean rmse map - {name}")
 
     plt.show()
     return fig, axes
@@ -192,16 +194,17 @@ def plot_reconstructions(maps: Sequence[np.ndarray], names: Sequence[str]):
     tuple
         Matplotlib ``(fig, axes)``.
     """
-    fig, axes = plt.subplots(1, len(maps), figsize=(20, 4))
+    fig, axes = plt.subplots(1, len(maps), figsize=(20, 4), squeeze=False)
+    axes = axes.flatten()
 
-    for i, simu in enumerate(maps):
+    for ax, simu, name in zip(axes, maps, names, strict=True):
         if len(np.shape(simu)) > 3:
-            im = axes[i].pcolor(simu[0, 0])
-            axes[i].set_title(f"Surface {names[i]}")
+            im = ax.pcolor(simu[0, 0])
+            ax.set_title(f"Surface {name}")
         else:
-            im = axes[i].pcolor(simu[0])
-            axes[i].set_title(f"{names[i]}")
-        plt.colorbar(im, ax=axes[i])
+            im = ax.pcolor(simu[0])
+            ax.set_title(f"{name}")
+        plt.colorbar(im, ax=ax)
 
     plt.show()
     return fig, axes
@@ -282,7 +285,8 @@ def plot_depth_error_profiles(
     tuple
         Matplotlib ``(fig, axes)``.
     """
-    fig, axes = plt.subplots(len(labels), 1, figsize=(10, 6))
+    fig, axes = plt.subplots(len(labels), 1, figsize=(10, 6), squeeze=False)
+    axes = axes.flatten()
 
     for i, label in enumerate(labels):
         axes[i].plot(
@@ -344,13 +348,14 @@ def plot_depth_prediction_reference(
     tuple
         Matplotlib ``(fig, axes)``.
     """
-    fig, axes = plt.subplots(1, len(titles), figsize=(15, 4))
+    fig, axes = plt.subplots(1, len(titles), figsize=(15, 4), squeeze=False)
+    axes = axes.flatten()
 
-    for i, title in enumerate(titles):
-        axes[i].plot(depth, mean_pred[i], label="predictions")
-        axes[i].plot(depth, mean_ref[i], label="reference")
-        axes[i].set_title(title)
-        axes[i].legend()
+    for ax, title, pred, ref in zip(axes, titles, mean_pred, mean_ref, strict=True):
+        ax.plot(depth, pred, label="predictions")
+        ax.plot(depth, ref, label="reference")
+        ax.set_title(title)
+        ax.legend()
 
     fig.suptitle("Average over depth")
     plt.show()
@@ -382,11 +387,14 @@ def plot_mean_profiles(
     tuple
         Matplotlib ``(fig, axes)``.
     """
-    fig, axes = plt.subplots(3, 1, figsize=(10, 8))
-    for i, ax in enumerate(axes):
-        ax.plot(mean_pred[i], color=colors[i], label=names[i])
-        ax.plot(mean_ref[i], color="grey", label="ref", linestyle="dashed")
-        ax.set_title(f"Mean profiles - {names[i]}")
+    fig, axes = plt.subplots(len(mean_pred), 1, figsize=(10, 8), squeeze=False)
+    axes = axes.flatten()
+    for ax, pred, ref, name, color in zip(
+        axes, mean_pred, mean_ref, names, colors, strict=True
+    ):
+        ax.plot(pred, color=color, label=name)
+        ax.plot(ref, color="grey", label="ref", linestyle="dashed")
+        ax.set_title(f"Mean profiles - {name}")
         ax.legend()
 
     plt.tight_layout()
@@ -425,21 +433,22 @@ def plot_component_timeseries(
     tuple
         Matplotlib ``(fig, axes)``.
     """
-    fig, axes = plt.subplots(3, 1, figsize=(10, 8))
+    fig, axes = plt.subplots(len(ref), 1, figsize=(10, 8), squeeze=False)
+    axes = axes.flatten()
 
-    for i, simu in enumerate(ref):
-        axes[i].plot(
-            simu.components[:, comp], color="grey", linestyle="dashed", label="ref"
-        )
-        axes[i].plot(
+    for ax, simu, pred_item, name, color in zip(
+        axes, ref, pred, names, colors, strict=True
+    ):
+        ax.plot(simu.components[:, comp], color="grey", linestyle="dashed", label="ref")
+        ax.plot(
             np.arange(0, total_len),
-            pred[i].iloc[:, comp],
-            color=colors[i],
+            pred_item.iloc[:, comp],
+            color=color,
             alpha=0.9,
-            label=names[i],
+            label=name,
         )
-        axes[i].set_title(f"Components - {names[i]}")
-        axes[i].legend()
+        ax.set_title(f"Components - {name}")
+        ax.legend()
     fig.suptitle("PCA INFO")
     plt.show()
     return fig, axes


### PR DESCRIPTION
## Change Description

Plotting functions were hardcoded for fixed data dimensions, contained unused code paths, and had visual issues including `pcolor` silently dropping the last row/column of data, missing axis labels, and the training/forecast concatenation being plotted as a single line — making it unclear where the actual prediction begins.

## Task List

- [x] Parameterise plotting functions to support arbitrary-length data
- [x] Remove unused SSCA branch
- [x] Remove `plot_mean_profiles` entirely — it duplicated `plot_depth_prediction_reference`
- [x] Restrict depth-profile plots to 4D variables only, not relevant for ssh
- [x] Add and parameterise missing axis labels, fix suptitle overlap with `tight_layout`
- [x] Replace `pcolor` with `pcolormesh`, use `zip(strict=True)`
- [x] Deduplicate `plot_rmse_maps` branches
- [x] Distinguish training vs forecast segments in `plot_component_timeseries` using dashed/solid lines

Addresses some of #98

Although not the focus of the PR, while reviewing the PR, if you spot any improvements that can be made to the Notebook. Please add them  to the issue here: #99 